### PR TITLE
PERF: Optimize Implementation2.cs

### DIFF
--- a/src/JOS.FlatDictionary/Implementation2.cs
+++ b/src/JOS.FlatDictionary/Implementation2.cs
@@ -70,7 +70,7 @@ namespace JOS.FlatDictionary
             }
         }
 
-        private static IEnumerable<PropertyInfo> GetProperties(Type type)
+        private static PropertyInfo[] GetProperties(Type type)
         {
             if (CachedTypeProperties.TryGetValue(type, out var result))
             {


### PR DESCRIPTION
Hi @joseftw, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|                           Method |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------- |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|         Implementation1Benchmark | 12.395 us | 0.2210 us | 0.1959 us |  1.00 |    0.00 | 2.9297 |     - |     - |   5.98 KB |
|         Implementation2Benchmark | 11.182 us | 0.2050 us | 0.1817 us |  0.90 |    0.02 | 2.6855 |     - |     - |   5.49 KB |
|         Implementation3Benchmark |  5.971 us | 0.0367 us | 0.0307 us |  0.48 |    0.01 | 2.5940 |     - |     - |    5.3 KB |
| ImplementationHardCodedBenchmark |  5.959 us | 0.0365 us | 0.0323 us |  0.48 |    0.01 | 2.6093 |     - |     - |   5.34 KB |

**Benchmarks after changes:**
|                           Method |      Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------- |----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|         Implementation1Benchmark | 12.405 us | 0.1325 us | 0.1106 us |  1.00 | 2.9297 |     - |     - |   5.98 KB |
|         Implementation2Benchmark | 10.859 us | 0.1154 us | 0.1079 us |  0.87 | 2.5940 |     - |     - |    5.3 KB |
|         Implementation3Benchmark |  6.077 us | 0.0891 us | 0.0790 us |  0.49 | 2.5940 |     - |     - |    5.3 KB |
| ImplementationHardCodedBenchmark |  5.926 us | 0.0528 us | 0.0441 us |  0.48 | 2.6093 |     - |     - |   5.34 KB |

As you can see the allocations (Implementation2Benchmark) have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!